### PR TITLE
Fix `NavigationStarting` & `NavigationCompleted` event for Avalonia.WebView.Android

### DIFF
--- a/Source/Platform/Android/Avalonia.WebView.Android/Clients/AvaloniaWebViewClient.cs
+++ b/Source/Platform/Android/Avalonia.WebView.Android/Clients/AvaloniaWebViewClient.cs
@@ -1,25 +1,25 @@
-﻿using WebViewCore.Enums;
+﻿using Android.Graphics;
+using WebViewCore.Enums;
 
 namespace Avalonia.WebView.Android.Clients;
 
 [SupportedOSPlatform("android23.0")]
 internal class AvaloniaWebViewClient : WebViewClient
 {
-    public AvaloniaWebViewClient(AndroidWebViewCore webViewHandler, IVirtualWebViewControlCallBack callBack, IVirtualBlazorWebViewProvider provider, WebScheme webScheme)
+    public AvaloniaWebViewClient(
+        AndroidWebViewCore webViewHandler,
+        IVirtualWebViewControlCallBack callBack
+    )
     {
         ArgumentNullException.ThrowIfNull(webViewHandler);
         ArgumentNullException.ThrowIfNull(callBack);
-        ArgumentNullException.ThrowIfNull(provider);
-        ArgumentNullException.ThrowIfNull(webScheme);
         _callBack = callBack;
         _webViewCore = webViewHandler;
-        _provider = provider;
         _webView = webViewHandler.WebView;
-        _webScheme = webScheme;
     }
 
-
-    protected AvaloniaWebViewClient(IntPtr javaReference, JniHandleOwnership transfer) : base(javaReference, transfer)
+    protected AvaloniaWebViewClient(IntPtr javaReference, JniHandleOwnership transfer)
+        : base(javaReference, transfer)
     {
         // This constructor is called whenever the .NET proxy was disposed, and it was recreated by Java. It also
         // happens when overridden methods are called between execution of this constructor and the one above.
@@ -29,53 +29,15 @@ internal class AvaloniaWebViewClient : WebViewClient
     readonly AndroidWebViewCore? _webViewCore;
     readonly AndroidWebView? _webView;
     readonly IVirtualWebViewControlCallBack? _callBack;
-    readonly IVirtualBlazorWebViewProvider? _provider;
-    readonly WebScheme? _webScheme;
 
-    bool _isStarted = false;
-
-    public override bool ShouldOverrideUrlLoading(AndroidWebView? view, IWebResourceRequest? request)
+    public override bool ShouldOverrideUrlLoading(
+        AndroidWebView? view,
+        IWebResourceRequest? request
+    )
 #pragma warning disable CA1416
-        => ShouldOverrideUrlLoadingCore(request) || base.ShouldOverrideUrlLoading(view, request);
+        =>
+        ShouldOverrideUrlLoadingCore(view, request) || base.ShouldOverrideUrlLoading(view, request);
 #pragma warning restore CA1416
-
-    public override AndroidWebResourceResponse? ShouldInterceptRequest(AndroidWebView? view, IWebResourceRequest? request)
-    {
-        ArgumentException.ThrowIfNullOrEmpty(nameof(request));
-        Func<AndroidWebResourceResponse?> func = () =>
-        {
-            if (_webScheme is null || _provider is null)
-                return default;
-
-            var requestUri = request?.Url?.ToString();
-            if (requestUri == null)
-                return default;
-
-            var allowFallbackOnHostPage = _webScheme.BaseUri.IsBaseOfPage(requestUri);
-
-            var webRequest = new WebResourceRequest
-            {
-                RequestUri = requestUri!,
-                AllowFallbackOnHostPage = allowFallbackOnHostPage
-            };
-
-            if (!_provider.PlatformWebViewResourceRequested(_webViewCore, webRequest, out var webResponse))
-                return default;
-
-            if (webResponse is null)
-                return default;
-
-            var contentType = webResponse.Headers[QueryStringHelper.ContentTypeKey];
-
-            return new AndroidWebResourceResponse(contentType, "UTF-8", webResponse.StatusCode, webResponse.StatusMessage, webResponse.Headers, webResponse.Content);
-        };
-        var ret = func.Invoke();
-
-        if (ret is null)
-            return base.ShouldInterceptRequest(view, request);
-        else
-            return ret;
-    }
 
     public override void OnPageFinished(AndroidWebView? view, string? url)
     {
@@ -83,20 +45,28 @@ internal class AvaloniaWebViewClient : WebViewClient
 
         if (view is null)
             return;
-
-        if (string.IsNullOrWhiteSpace(url))
+        System.Diagnostics.Debug.WriteLine($"OnPageFinished: {url}");
+        if (_callBack is null || !Uri.TryCreate(url, UriKind.RelativeOrAbsolute, out var uri))
             return;
-
-        if (_webScheme is null)
-            return;
-
-        if (_webScheme.BaseUri.IsBaseOfPage(url))
-            RunBlazorStarupScripts();
+        _callBack.PlatformWebViewNavigationCompleted(
+            _webViewCore,
+            new WebViewUrlLoadedEventArg { IsSuccess = true }
+        );
     }
 
-    bool ShouldOverrideUrlLoadingCore(IWebResourceRequest? request)
+    bool ShouldOverrideUrlLoadingCore(AndroidWebView? view, IWebResourceRequest? request)
     {
-        if (_callBack is null || !Uri.TryCreate(request?.Url?.ToString(), UriKind.RelativeOrAbsolute, out var uri))
+        if (view is null)
+        {
+            return false;
+        }
+        System.Diagnostics.Debug.WriteLine(
+            $"ShouldOverrideUrlLoadingCore: {request?.Url?.ToString()}"
+        );
+        if (
+            _callBack is null
+            || !Uri.TryCreate(request?.Url?.ToString(), UriKind.RelativeOrAbsolute, out var uri)
+        )
             return false;
         WebViewUrlLoadingEventArg args = new() { Url = uri, RawArgs = request };
         _callBack.PlatformWebViewNavigationStarting(_webViewCore, args);
@@ -125,71 +95,15 @@ internal class AvaloniaWebViewClient : WebViewClient
                 _webView?.LoadUrl(uri.OriginalString);
                 isSucceed = true;
                 break;
-            case UrlRequestStrategy.CancelLoad:            
+            case UrlRequestStrategy.CancelLoad:
                 break;
             default:
                 break;
         }
-
-        _callBack.PlatformWebViewNavigationCompleted(_webViewCore, new WebViewUrlLoadedEventArg() {IsSuccess = isSucceed });
-
+        _callBack.PlatformWebViewNavigationCompleted(
+            _webViewCore,
+            new WebViewUrlLoadedEventArg { IsSuccess = isSucceed }
+        );
         return true;
     }
-
-    void RunBlazorStarupScripts()
-    {
-        if (_webView is null)
-            return;
-
-        _webView.EvaluateJavascript(BlazorScriptHelper.BlazorStartedScript, new JavaScriptValueCallback(blazorStarted =>
-        {
-            var result = blazorStarted?.ToString();
-
-            if (result != BlazorScriptHelper.UndefinedString)
-                return;
-
-            _webView.EvaluateJavascript(BlazorScriptHelper.BlazorMessageScript, new JavaScriptValueCallback(_ =>
-            {
-                _isStarted = true;
-                BlazorMessageChannel(_webView, _provider!);
-
-                _webView.EvaluateJavascript(BlazorScriptHelper.BlazorStartingScript, new JavaScriptValueCallback(_ =>
-                {
-
-                }));
-
-            }));
-        }));
-    }
-
-    void BlazorMessageChannel(AndroidWebView webView, IVirtualBlazorWebViewProvider provider)
-    {
-        if (webView is null)
-            return;
-
-        if (provider is null)
-            return;
-
-        if (_webScheme is null)
-            return;
-
-        var nativeToJSPorts = webView.CreateWebMessageChannel();
-        var nativeToJs = new BlazorWebMessageCallback(message =>
-        {
-            if (string.IsNullOrWhiteSpace(message))
-                return;
-
-              provider.PlatformWebViewMessageReceived(_webViewCore, new WebViewMessageReceivedEventArgs() 
-              {
-                  Source = _webScheme.BaseUri,
-                  Message = message
-              });
-        });
-
-        var destPort = new[] { nativeToJSPorts[1] };
-        nativeToJSPorts[0].SetWebMessageCallback(nativeToJs);
-
-        webView.PostWebMessage(new WebMessage("capturePort", destPort), AndroidUri.Parse(_webScheme.BaseUri.AbsoluteUri)!);
-    }
-
 }

--- a/Source/Platform/Android/Avalonia.WebView.Android/Clients/Blazor/AvaloniaBlazorWebChromeClient.cs
+++ b/Source/Platform/Android/Avalonia.WebView.Android/Clients/Blazor/AvaloniaBlazorWebChromeClient.cs
@@ -1,8 +1,8 @@
-﻿namespace Avalonia.WebView.Android.Clients;
+﻿namespace Avalonia.WebView.Android.Clients.Blazor;
 
-internal class AvaloniaWebChromeClient : WebChromeClient
+internal class AvaloniaBlazorWebChromeClient : WebChromeClient
 {
-    public AvaloniaWebChromeClient(AndroidWebViewCore androidWebViewCore)
+    public AvaloniaBlazorWebChromeClient(AndroidWebViewCore androidWebViewCore)
     {
         _androidWebViewCore = androidWebViewCore;
         var topLevel = androidWebViewCore.GetTopLevel();
@@ -15,7 +15,12 @@ internal class AvaloniaWebChromeClient : WebChromeClient
     readonly AndroidWebViewCore _androidWebViewCore;
     readonly TopLevel _topLevel;
 
-    public override bool OnCreateWindow(AndroidWebView? view, bool isDialog, bool isUserGesture, Message? resultMsg)
+    public override bool OnCreateWindow(
+        AndroidWebView? view,
+        bool isDialog,
+        bool isUserGesture,
+        Message? resultMsg
+    )
     {
         if (view?.Context is not null)
         {
@@ -28,7 +33,11 @@ internal class AvaloniaWebChromeClient : WebChromeClient
         return false;
     }
 
-    public override bool OnShowFileChooser(AndroidWebView? webView, IValueCallback? filePathCallback, FileChooserParams? fileChooserParams)
+    public override bool OnShowFileChooser(
+        AndroidWebView? webView,
+        IValueCallback? filePathCallback,
+        FileChooserParams? fileChooserParams
+    )
     {
         if (filePathCallback is null)
             return base.OnShowFileChooser(webView, filePathCallback, fileChooserParams);
@@ -37,7 +46,10 @@ internal class AvaloniaWebChromeClient : WebChromeClient
         return true;
     }
 
-    private async Task CallFilePickerAsync(IValueCallback filePathCallback, FileChooserParams? fileChooserParams)
+    private async Task CallFilePickerAsync(
+        IValueCallback filePathCallback,
+        FileChooserParams? fileChooserParams
+    )
     {
         var pickOptions = GetPickOptions(fileChooserParams);
         if (pickOptions is null)
@@ -76,7 +88,10 @@ internal class AvaloniaWebChromeClient : WebChromeClient
             return default;
 
         var acceptedFileTypes = fileChooserParams.GetAcceptTypes();
-        if (acceptedFileTypes is null || (acceptedFileTypes.Length == 1 && string.IsNullOrEmpty(acceptedFileTypes[0])))
+        if (
+            acceptedFileTypes is null
+            || (acceptedFileTypes.Length == 1 && string.IsNullOrEmpty(acceptedFileTypes[0]))
+        )
             return null;
 
         bool allowMultiple = fileChooserParams.Mode == ChromeFileChooserMode.OpenMultiple;
@@ -86,15 +101,14 @@ internal class AvaloniaWebChromeClient : WebChromeClient
             AllowMultiple = allowMultiple,
             FileTypeFilter = new List<FilePickerFileType>()
             {
-                 new FilePickerFileType("Accepted File")
-                 {
-                     Patterns = acceptedFileTypes,
-                     AppleUniformTypeIdentifiers = new string[1] { "public.accepted"},
-                     MimeTypes = new string[1] { "accepted/*" }
-                 }
+                new FilePickerFileType("Accepted File")
+                {
+                    Patterns = acceptedFileTypes,
+                    AppleUniformTypeIdentifiers = new string[1] { "public.accepted" },
+                    MimeTypes = new string[1] { "accepted/*" }
+                }
             }
         };
         return pickOptions;
     }
 }
-

--- a/Source/Platform/Android/Avalonia.WebView.Android/Clients/Blazor/AvaloniaBlazorWebViewClient.cs
+++ b/Source/Platform/Android/Avalonia.WebView.Android/Clients/Blazor/AvaloniaBlazorWebViewClient.cs
@@ -1,0 +1,235 @@
+﻿using WebViewCore.Enums;
+
+namespace Avalonia.WebView.Android.Clients.Blazor;
+
+[SupportedOSPlatform("android23.0")]
+internal class AvaloniaBlazorWebViewClient : WebViewClient
+{
+    public AvaloniaBlazorWebViewClient(
+        AndroidWebViewCore webViewHandler,
+        IVirtualWebViewControlCallBack callBack,
+        IVirtualBlazorWebViewProvider provider,
+        WebScheme webScheme
+    )
+    {
+        ArgumentNullException.ThrowIfNull(webViewHandler);
+        ArgumentNullException.ThrowIfNull(callBack);
+        ArgumentNullException.ThrowIfNull(provider);
+        ArgumentNullException.ThrowIfNull(webScheme);
+        _callBack = callBack;
+        _webViewCore = webViewHandler;
+        _provider = provider;
+        _webView = webViewHandler.WebView;
+        _webScheme = webScheme;
+    }
+
+    protected AvaloniaBlazorWebViewClient(IntPtr javaReference, JniHandleOwnership transfer)
+        : base(javaReference, transfer)
+    {
+        // This constructor is called whenever the .NET proxy was disposed, and it was recreated by Java. It also
+        // happens when overridden methods are called between execution of this constructor and the one above.
+        // because of these facts, we have to check all methods below for null field references and properties.
+    }
+
+    readonly AndroidWebViewCore? _webViewCore;
+    readonly AndroidWebView? _webView;
+    readonly IVirtualWebViewControlCallBack? _callBack;
+    readonly IVirtualBlazorWebViewProvider? _provider;
+    readonly WebScheme? _webScheme;
+
+    bool _isStarted = false;
+
+    public override bool ShouldOverrideUrlLoading(
+        AndroidWebView? view,
+        IWebResourceRequest? request
+    )
+#pragma warning disable CA1416
+        => ShouldOverrideUrlLoadingCore(request) || base.ShouldOverrideUrlLoading(view, request);
+#pragma warning restore CA1416
+
+    public override AndroidWebResourceResponse? ShouldInterceptRequest(
+        AndroidWebView? view,
+        IWebResourceRequest? request
+    )
+    {
+        ArgumentException.ThrowIfNullOrEmpty(nameof(request));
+        Func<AndroidWebResourceResponse?> func = () =>
+        {
+            if (_webScheme is null || _provider is null)
+                return default;
+
+            var requestUri = request?.Url?.ToString();
+            if (requestUri == null)
+                return default;
+
+            var allowFallbackOnHostPage = _webScheme.BaseUri.IsBaseOfPage(requestUri);
+
+            var webRequest = new WebResourceRequest
+            {
+                RequestUri = requestUri!,
+                AllowFallbackOnHostPage = allowFallbackOnHostPage
+            };
+
+            if (
+                !_provider.PlatformWebViewResourceRequested(
+                    _webViewCore,
+                    webRequest,
+                    out var webResponse
+                )
+            )
+                return default;
+
+            if (webResponse is null)
+                return default;
+
+            var contentType = webResponse.Headers[QueryStringHelper.ContentTypeKey];
+
+            return new AndroidWebResourceResponse(
+                contentType,
+                "UTF-8",
+                webResponse.StatusCode,
+                webResponse.StatusMessage,
+                webResponse.Headers,
+                webResponse.Content
+            );
+        };
+        var ret = func.Invoke();
+
+        if (ret is null)
+            return base.ShouldInterceptRequest(view, request);
+        else
+            return ret;
+    }
+
+    public override void OnPageFinished(AndroidWebView? view, string? url)
+    {
+        base.OnPageFinished(view, url);
+
+        if (view is null)
+            return;
+
+        if (string.IsNullOrWhiteSpace(url))
+            return;
+
+        if (_webScheme is null)
+            return;
+
+        if (_webScheme.BaseUri.IsBaseOfPage(url))
+            RunBlazorStarupScripts();
+    }
+
+    bool ShouldOverrideUrlLoadingCore(IWebResourceRequest? request)
+    {
+        if (
+            _callBack is null
+            || !Uri.TryCreate(request?.Url?.ToString(), UriKind.RelativeOrAbsolute, out var uri)
+        )
+            return false;
+        WebViewUrlLoadingEventArg args = new() { Url = uri, RawArgs = request };
+        _callBack.PlatformWebViewNavigationStarting(_webViewCore, args);
+        if (args.Cancel)
+            return false;
+
+        var newWindowEventArgs = new WebViewNewWindowEventArgs()
+        {
+            Url = uri,
+            UrlLoadingStrategy = UrlRequestStrategy.OpenInWebView
+        };
+
+        if (!_callBack.PlatformWebViewNewWindowRequest(_webViewCore, newWindowEventArgs))
+            return false;
+
+        bool isSucceed = false;
+        switch (newWindowEventArgs.UrlLoadingStrategy)
+        {
+            case UrlRequestStrategy.OpenExternally:
+            case UrlRequestStrategy.OpenInNewWindow:
+                var intent = Intent.ParseUri(uri.OriginalString, IntentUriType.Scheme);
+                AndroidApplication.Context.StartActivity(intent);
+                isSucceed = true;
+                break;
+            case UrlRequestStrategy.OpenInWebView:
+                _webView?.LoadUrl(uri.OriginalString);
+                isSucceed = true;
+                break;
+            case UrlRequestStrategy.CancelLoad:
+                break;
+            default:
+                break;
+        }
+
+        _callBack.PlatformWebViewNavigationCompleted(
+            _webViewCore,
+            new WebViewUrlLoadedEventArg() { IsSuccess = isSucceed }
+        );
+
+        return true;
+    }
+
+    void RunBlazorStarupScripts()
+    {
+        if (_webView is null)
+            return;
+
+        _webView.EvaluateJavascript(
+            BlazorScriptHelper.BlazorStartedScript,
+            new JavaScriptValueCallback(blazorStarted =>
+            {
+                var result = blazorStarted?.ToString();
+
+                if (result != BlazorScriptHelper.UndefinedString)
+                    return;
+
+                _webView.EvaluateJavascript(
+                    BlazorScriptHelper.BlazorMessageScript,
+                    new JavaScriptValueCallback(_ =>
+                    {
+                        _isStarted = true;
+                        BlazorMessageChannel(_webView, _provider!);
+
+                        _webView.EvaluateJavascript(
+                            BlazorScriptHelper.BlazorStartingScript,
+                            new JavaScriptValueCallback(_ => { })
+                        );
+                    })
+                );
+            })
+        );
+    }
+
+    void BlazorMessageChannel(AndroidWebView webView, IVirtualBlazorWebViewProvider provider)
+    {
+        if (webView is null)
+            return;
+
+        if (provider is null)
+            return;
+
+        if (_webScheme is null)
+            return;
+
+        var nativeToJSPorts = webView.CreateWebMessageChannel();
+        var nativeToJs = new BlazorWebMessageCallback(message =>
+        {
+            if (string.IsNullOrWhiteSpace(message))
+                return;
+
+            provider.PlatformWebViewMessageReceived(
+                _webViewCore,
+                new WebViewMessageReceivedEventArgs()
+                {
+                    Source = _webScheme.BaseUri,
+                    Message = message
+                }
+            );
+        });
+
+        var destPort = new[] { nativeToJSPorts[1] };
+        nativeToJSPorts[0].SetWebMessageCallback(nativeToJs);
+
+        webView.PostWebMessage(
+            new WebMessage("capturePort", destPort),
+            AndroidUri.Parse(_webScheme.BaseUri.AbsoluteUri)!
+        );
+    }
+}

--- a/Source/Platform/Android/Avalonia.WebView.Android/Core/AndroidWebViewCore-core.cs
+++ b/Source/Platform/Android/Avalonia.WebView.Android/Core/AndroidWebViewCore-core.cs
@@ -1,8 +1,13 @@
-﻿namespace Avalonia.WebView.Android.Core;
+﻿using Avalonia.WebView.Android.Clients.Blazor;
+
+namespace Avalonia.WebView.Android.Core;
 
 partial class AndroidWebViewCore
 {
-    Task<bool> PrepareBlazorWebViewStarting(AndroidWebView webView, IVirtualBlazorWebViewProvider? provider)
+    Task<bool> PrepareBlazorWebViewStarting(
+        AndroidWebView webView,
+        IVirtualBlazorWebViewProvider? provider
+    )
     {
         if (webView is null)
             return Task.FromResult(false);
@@ -13,8 +18,8 @@ partial class AndroidWebViewCore
         if (!provider.ResourceRequestedFilterProvider(this, out var filter))
             return Task.FromResult(false);
 
-        _webViewClient = new AvaloniaWebViewClient(this, _callBack, provider, filter);
-        _webChromeClient = new AvaloniaWebChromeClient(this);
+        _webViewClient = new AvaloniaBlazorWebViewClient(this, _callBack, provider, filter);
+        _webChromeClient = new AvaloniaBlazorWebChromeClient(this);
         webView.SetWebViewClient(_webViewClient);
         webView.SetWebChromeClient(_webChromeClient);
         _isBlazorWebView = true;
@@ -26,4 +31,3 @@ partial class AndroidWebViewCore
         _isBlazorWebView = false;
     }
 }
-

--- a/Source/Platform/Android/Avalonia.WebView.Android/Core/AndroidWebViewCore-override.cs
+++ b/Source/Platform/Android/Avalonia.WebView.Android/Core/AndroidWebViewCore-override.cs
@@ -66,7 +66,9 @@ partial class AndroidWebViewCore
         var bRet = await PrepareBlazorWebViewStarting(webView, _provider);
         if (!bRet)
         {
-            _webViewClient = new WebViewClient();
+#pragma warning disable CA1416 // Validate platform compatibility
+            _webViewClient = new AvaloniaWebViewClient(this, _callBack);
+#pragma warning restore CA1416 // Validate platform compatibility
             _webChromeClient = new WebChromeClient();
             webView.SetWebViewClient(_webViewClient);
             webView.SetWebChromeClient(_webChromeClient);

--- a/Source/Platform/Android/Avalonia.WebView.Android/Core/AndroidWebViewCore-override.cs
+++ b/Source/Platform/Android/Avalonia.WebView.Android/Core/AndroidWebViewCore-override.cs
@@ -16,12 +16,12 @@ partial class AndroidWebViewCore
 
     Task<string?> IWebViewControl.ExecuteScriptAsync(string javaScript)
     {
-        _webView.EvaluateJavascript(javaScript, new JavaScriptValueCallback(result =>
-        {
-
-
-        }));
-        throw new NotImplementedException();
+        var cts = new TaskCompletionSource<string?>();
+        _webView.EvaluateJavascript(
+            javaScript,
+            new JavaScriptValueCallback(result => cts.TrySetResult(result?.ToString()))
+        );
+        return cts.Task;
     }
 
     bool IWebViewControl.GoBack()


### PR DESCRIPTION
1. Fixed `NavigationStarting` and `NavigationCompleted` events on the Avalonia.WebView.Android (non-Blazor mode).
2. Implemented IWebViewControl.ExecuteScriptAsync for the Avalonia.WebView.Android.

---

1. 修复安卓端（非Blazor模式）无法触发`NavigationStarting`和`NavigationCompleted`事件的bug
   - `Clients\AvaloniaWebViewClient.cs`移到`Clients\Blazor\AvaloniaBlazorWebViewClient.cs`，实现`AvaloniaWebViewClient`用于非Blazor模式的WebViewClient，相应对应事件
2.  实现安卓端的 `IWebViewControl.ExecuteScriptAsync`用`TaskCompletionSource`转成普通异步。
     ```cs
      var cts = new TaskCompletionSource<string?>();
        _webView.EvaluateJavascript(
            javaScript,
            new JavaScriptValueCallback(result => cts.TrySetResult(result?.ToString()))
        );
        return cts.Task;
     ```